### PR TITLE
Update ExaMiniMD for Kokkos v3.0 promotion

### DIFF
--- a/src/examinimd.cpp
+++ b/src/examinimd.cpp
@@ -159,7 +159,7 @@ void ExaMiniMD::init(int argc, char* argv[]) {
       } else {
         printf("\n");
         printf("Step Temp E_pair TotEng CPU\n");
-        printf("     %i %lf %lf %lf %lf %e\n",step,T,PE,PE+KE,0.0);
+        printf("     %i %lf %lf %lf %lf\n",step,T,PE,PE+KE,0.0);
       }
     }
   }

--- a/src/force_types/force_snap_neigh_impl.h
+++ b/src/force_types/force_snap_neigh_impl.h
@@ -137,7 +137,7 @@ template<class NeighList>
 struct FindMaxNumNeighs {
   NeighList neigh_list;
 
-  FindMaxNumNeighs(NeighList& nl): neigh_list(nl) {}  
+  FindMaxNumNeighs(NeighList& nl): neigh_list(nl) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator() (const int& i, int& max_neighs) const {
@@ -172,7 +172,7 @@ void ForceSNAP<NeighborClass>::compute(System* system, Binning* binning, Neighbo
     const int num_neighs = neighs_i.get_num_neighs();
     if(max_neighs<num_neighs) max_neighs = num_neighs;
   }*/
-  Kokkos::parallel_reduce("ForceSNAP::find_max_neighs",nlocal, FindMaxNumNeighs<t_neigh_list>(neigh_list), Kokkos::Experimental::Max<int>(max_neighs));
+  Kokkos::parallel_reduce("ForceSNAP::find_max_neighs",nlocal, FindMaxNumNeighs<t_neigh_list>(neigh_list), Kokkos::Max<int>(max_neighs));
 
   sna.nmax = max_neighs;
 
@@ -272,8 +272,8 @@ void ForceSNAP<NeighborClass>::init_coeff(int narg, char **arg)
 
     // ncoeffall should be (ncoeff+2)*(ncoeff+1)/2
     // so, ncoeff = floor(sqrt(2*ncoeffall))-1
-    
-    ncoeff = sqrt(2*ncoeffall)-1; 
+
+    ncoeff = sqrt(2*ncoeffall)-1;
     ncoeffq = (ncoeff*(ncoeff+1))/2;
     int ntmp = 1+ncoeff+ncoeffq;
     if (ntmp != ncoeffall) {
@@ -384,7 +384,7 @@ void ForceSNAP<NeighborClass>::read_files(char *coefffilename, char *paramfilena
 
   int nelemfile = atoi(words[0]);
   ncoeffall = atoi(words[1]);
-  
+
   // Set up element lists
 
   radelem = Kokkos::View<T_F_FLOAT*>("pair:radelem",nelements);
@@ -504,7 +504,7 @@ void ForceSNAP<NeighborClass>::read_files(char *coefffilename, char *paramfilena
   switchflag = 1;
   bzeroflag = 1;
   quadraticflag = 0;
-  
+
   // open SNAP parameter file on proc 0
 
   FILE *fpparam;
@@ -537,7 +537,7 @@ void ForceSNAP<NeighborClass>::read_files(char *coefffilename, char *paramfilena
     //nwords = atom->count_words(line);
     if(line[0]!=10) nwords = 2; else nwords = 0;
     if (nwords == 0) continue;
-    
+
     if (nwords != 2)
       Kokkos::abort("Incorrect format in SNAP parameter file");
 
@@ -548,7 +548,7 @@ void ForceSNAP<NeighborClass>::read_files(char *coefffilename, char *paramfilena
     char* keyval = strtok(NULL,"' \t\n\r\f");
 
     //if (comm->me == 0) {
-      //if (screen) 
+      //if (screen)
       //if (logfile) fprintf(logfile,"SNAP keyword %s %s \n",keywd,keyval);
     //}
 

--- a/src/force_types/force_snap_neigh_impl.h
+++ b/src/force_types/force_snap_neigh_impl.h
@@ -180,8 +180,8 @@ void ForceSNAP<NeighborClass>::compute(System* system, Binning* binning, Neighbo
   T_INT thread_scratch_size = sna.size_thread_scratch_arrays();
 
   //printf("Sizes: %i %i\n",team_scratch_size/1024,thread_scratch_size/1024);
-  int team_size_max = Kokkos::TeamPolicy<>(1,1).team_size_max(*this,Kokkos::ParallelForTag());
   int vector_length = 8;
+  int team_size_max = Kokkos::TeamPolicy<>(nlocal,Kokkos::AUTO).team_size_max(*this,Kokkos::ParallelForTag());
 #ifdef KOKKOS_ENABLE_CUDA
   int team_size = 20;//max_neighs;
   if(team_size*vector_length > team_size_max)

--- a/src/force_types/force_snap_neigh_impl.h
+++ b/src/force_types/force_snap_neigh_impl.h
@@ -180,7 +180,7 @@ void ForceSNAP<NeighborClass>::compute(System* system, Binning* binning, Neighbo
   T_INT thread_scratch_size = sna.size_thread_scratch_arrays();
 
   //printf("Sizes: %i %i\n",team_scratch_size/1024,thread_scratch_size/1024);
-  int team_size_max = Kokkos::TeamPolicy<>::team_size_max(*this);
+  int team_size_max = Kokkos::TeamPolicy<>(team_scratch_size,thread_scratch_size).team_size_max(*this,Kokkos::ParallelForTag());
   int vector_length = 8;
 #ifdef KOKKOS_ENABLE_CUDA
   int team_size = 20;//max_neighs;

--- a/src/force_types/force_snap_neigh_impl.h
+++ b/src/force_types/force_snap_neigh_impl.h
@@ -180,7 +180,7 @@ void ForceSNAP<NeighborClass>::compute(System* system, Binning* binning, Neighbo
   T_INT thread_scratch_size = sna.size_thread_scratch_arrays();
 
   //printf("Sizes: %i %i\n",team_scratch_size/1024,thread_scratch_size/1024);
-  int team_size_max = Kokkos::TeamPolicy<>(team_scratch_size,thread_scratch_size).team_size_max(*this,Kokkos::ParallelForTag());
+  int team_size_max = Kokkos::TeamPolicy<>(1,1).team_size_max(*this,Kokkos::ParallelForTag());
   int vector_length = 8;
 #ifdef KOKKOS_ENABLE_CUDA
   int team_size = 20;//max_neighs;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -90,7 +90,7 @@ void ItemizedFile::print_line(int i) {
 
 int ItemizedFile::words_in_line(int i){
   int count = 0;
-  for(int j=0; j<words_per_line; j++) 
+  for(int j=0; j<words_per_line; j++)
     if(words[i][j][0]) count++;
   return count;
 }
@@ -203,7 +203,7 @@ void Input::read_command_line_args(int argc, char* argv[]) {
       dumpbinaryflag = true;
       i += 2;
     }
-    
+
     // Correctness Check
     else if( (strcmp(argv[i], "--correctness") == 0) ) {
       correctness_rate = atoi(argv[i+1]);
@@ -264,7 +264,7 @@ void Input::read_lammps_file(const char* filename) {
 
 void Input::check_lammps_command(int line) {
   bool known = false;
-  
+
   if(input_data.words[line][0][0]==0) { known = true; }
   if(strstr(input_data.words[line][0],"#")) { known = true; }
   if(strcmp(input_data.words[line][0],"variable")==0) {
@@ -374,7 +374,7 @@ void Input::check_lammps_command(int line) {
       force_type = FORCE_LJ;
       force_cutoff = atof(input_data.words[line][2]);
       force_line = line;
-    } 
+    }
     if(strcmp(input_data.words[line][1],"snap")==0) {
       known = true;
       force_type = FORCE_SNAP;
@@ -386,7 +386,7 @@ void Input::check_lammps_command(int line) {
   }
   if(strcmp(input_data.words[line][0],"pair_coeff")==0) {
     known = true;
-    int n_coeff_lines = force_coeff_lines.dimension_0();
+    int n_coeff_lines = force_coeff_lines.extent(0);
     Kokkos::resize(force_coeff_lines,n_coeff_lines+1);
     force_coeff_lines( n_coeff_lines) = line;
     n_coeff_lines++;
@@ -426,7 +426,7 @@ void Input::check_lammps_command(int line) {
   }
   if(strcmp(input_data.words[line][0],"run")==0) {
     known = true;
-    nsteps = atoi(input_data.words[line][1]);    
+    nsteps = atoi(input_data.words[line][1]);
   }
   if(strcmp(input_data.words[line][0],"thermo")==0) {
     known = true;
@@ -472,9 +472,9 @@ void Input::create_lattice(Comm* comm) {
 
   // Create Simple Cubic Lattice
   if(lattice_style == LATTICE_SC) {
-    system->domain_x = lattice_constant * lattice_nx; 
-    system->domain_y = lattice_constant * lattice_ny; 
-    system->domain_z = lattice_constant * lattice_nz; 
+    system->domain_x = lattice_constant * lattice_nx;
+    system->domain_y = lattice_constant * lattice_ny;
+    system->domain_z = lattice_constant * lattice_nz;
 
     comm->create_domain_decomposition();
     s = *system;
@@ -727,7 +727,7 @@ void Input::create_lattice(Comm* comm) {
   // velocity geom option, i.e. uniform random kinetic energies.
   // zero out momentum of the whole system afterwards, to eliminate
   // drift (bad for energy statistics)
-  
+
   {  // Scope s
     System s = *system;
     T_FLOAT total_mass = 0.0;

--- a/src/neighbor_types/neighbor_csr.h
+++ b/src/neighbor_types/neighbor_csr.h
@@ -79,7 +79,7 @@
 #include <binning.h>
 
 template<class MemorySpace>
-struct NeighListCSR : public Kokkos::StaticCrsGraph<T_INT,Kokkos::LayoutLeft,MemorySpace,T_INT> {
+struct NeighListCSR : public Kokkos::StaticCrsGraph<T_INT,Kokkos::LayoutLeft,MemorySpace,void,T_INT> {
   struct NeighViewCSR {
     private:
       const T_INT* const ptr;
@@ -100,14 +100,14 @@ struct NeighListCSR : public Kokkos::StaticCrsGraph<T_INT,Kokkos::LayoutLeft,Mem
   typedef NeighViewCSR t_neighs;
 
   NeighListCSR() :
-    Kokkos::StaticCrsGraph<T_INT,Kokkos::LayoutLeft,MemorySpace,T_INT>() {}
+    Kokkos::StaticCrsGraph<T_INT,Kokkos::LayoutLeft,MemorySpace,void,T_INT>() {}
   NeighListCSR (const NeighListCSR& rhs) :
-    Kokkos::StaticCrsGraph<T_INT,Kokkos::LayoutLeft,MemorySpace,T_INT>(rhs) {
+    Kokkos::StaticCrsGraph<T_INT,Kokkos::LayoutLeft,MemorySpace,void,T_INT>(rhs) {
   }
 
   template<class EntriesType, class RowMapType>
   NeighListCSR (const EntriesType& entries_,const RowMapType& row_map_) :
-    Kokkos::StaticCrsGraph<T_INT,Kokkos::LayoutLeft,MemorySpace,T_INT>( entries_, row_map_) {}
+    Kokkos::StaticCrsGraph<T_INT,Kokkos::LayoutLeft,MemorySpace,void,T_INT>( entries_, row_map_) {}
 
 
   KOKKOS_INLINE_FUNCTION
@@ -274,10 +274,10 @@ public:
        for(int by_j = by-1; by_j<by+2; by_j++)
        for(int bz_j = bz-1; bz_j<bz+2; bz_j++) {
 
-       /*  if( ( (bx_j<bx) || ((bx_j == bx) && ( (by_j>by) ||  ((by_j==by) && (bz_j>bz) )))) &&    
-             (bx_j>=nhalo) && (bx_j<nbinx+nhalo-1) &&    
+       /*  if( ( (bx_j<bx) || ((bx_j == bx) && ( (by_j>by) ||  ((by_j==by) && (bz_j>bz) )))) &&
+             (bx_j>=nhalo) && (bx_j<nbinx+nhalo-1) &&
              (by_j>=nhalo) && (by_j<nbiny+nhalo-1) &&
-             (bz_j>=nhalo) && (bz_j<nbinz+nhalo-1)    
+             (bz_j>=nhalo) && (bz_j<nbinz+nhalo-1)
            ) continue;
 */
          const T_INT j_offset = bin_offsets(bx_j,by_j,bz_j);
@@ -327,10 +327,10 @@ public:
        for(int by_j = by-1; by_j<by+2; by_j++)
        for(int bz_j = bz-1; bz_j<bz+2; bz_j++) {
 /*
-         if( ( (bx_j<bx) || ((bx_j == bx) && ( (by_j>by) ||  ((by_j==by) && (bz_j>bz) )))) && 
-             (bx_j>nhalo) && (bx_j<nbinx+nhalo-2) && 
+         if( ( (bx_j<bx) || ((bx_j == bx) && ( (by_j>by) ||  ((by_j==by) && (bz_j>bz) )))) &&
+             (bx_j>nhalo) && (bx_j<nbinx+nhalo-2) &&
              (by_j>nhalo) && (by_j<nbiny+nhalo-2) &&
-             (bz_j>nhalo) && (bz_j<nbinz+nhalo-2) 
+             (bz_j>nhalo) && (bz_j<nbinz+nhalo-2)
            ) continue;*/
          const T_INT j_offset = bin_offsets(bx_j,by_j,bz_j);
 


### PR DESCRIPTION
This pull request updates ExaMiniMD for the Kokkos version 3.0 promotion, and works with deprecated code disabled (KOKKOS_OPTIONS= disable_deprecated_code). There will be a complete removal of deprecated code support after the Kokkos version 3.0 release, hence this pull request. Current status and timeline for Kokkos code deprecations is at: https://github.com/kokkos/kokkos/wiki/DeprecationPage

This pull request corresponds to issue #27.

Please note that with this pull request, ExaMiniMD no longer builds with deprecated code enabled (KOKKOS_OPTIONS=enable_deprecated_code), due to the implementation of StaticCrsGraph (Kokkos_StaticCrsGraph.hpp) not using variadic templates (e.g., order of template arguments matters).