### PR TITLE
Atempt to make ExaMiniMD work with OpenMPTarget

### DIFF
--- a/src/examinimd.cpp
+++ b/src/examinimd.cpp
@@ -59,7 +59,7 @@ ExaMiniMD::ExaMiniMD() {
 void ExaMiniMD::init(int argc, char* argv[]) {
 
   if(system->do_print)
-    Kokkos::DefaultExecutionSpace::print_configuration(std::cout);
+    Kokkos::print_configuration(std::cout);
 
   // Lets parse the command line arguments
   input->read_command_line_args(argc,argv);

--- a/src/force_types/force_snap_neigh.cpp
+++ b/src/force_types/force_snap_neigh.cpp
@@ -36,8 +36,11 @@
 //  Questions? Contact Christian R. Trott (crtrott@sandia.gov)
 //************************************************************************
 
+#include<Kokkos_Macros.hpp>
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 #include<force_snap_neigh_impl.h>
 #define FORCETYPE_DECLARE_TEMPLATE_MACRO(NeighType) ForceSNAP<NeighType>
 #define FORCE_MODULES_TEMPLATE
 #include<modules_neighbor.h>
 #undef FORCE_MODULES_TEMPLATE
+#endif

--- a/src/modules_force.h
+++ b/src/modules_force.h
@@ -37,7 +37,10 @@
 //************************************************************************
 
 // Include Module header files for force
+#include<Kokkos_Macros.hpp>
 #include <force_lj_cell.h>
 #include <force_lj_neigh.h>
 #include <force_lj_idial_neigh.h>
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 #include <force_snap_neigh.h>
+#endif

--- a/src/types.h
+++ b/src/types.h
@@ -179,7 +179,7 @@ t_scalar3<Scalar> operator *
   return t_scalar3<Scalar>(a.x*b,a.y*b,a.z*b);
 }
 
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_OPENMPTARGET) || defined(KOKKOS_ENABLE_SYCL)
 #define EMD_ENABLE_GPU
 #endif
 


### PR DESCRIPTION
This compiles now (leaving out the SNAP potential which requires,
ThreadVector level paralle_scan), but fails to do mandatory offload
for a couple kernels (sorting, neighborlist construction) in the LJ example.