### PR TITLE
Fix running with the SYCL backend

### DIFF
--- a/src/examinimd.cpp
+++ b/src/examinimd.cpp
@@ -59,7 +59,7 @@ ExaMiniMD::ExaMiniMD() {
 void ExaMiniMD::init(int argc, char* argv[]) {
 
   if(system->do_print)
-    Kokkos::DefaultExecutionSpace::print_configuration(std::cout);
+    Kokkos::DefaultExecutionSpace{}.print_configuration(std::cout);
 
   // Lets parse the command line arguments
   input->read_command_line_args(argc,argv);

--- a/src/force_types/force_snap_neigh_impl.h
+++ b/src/force_types/force_snap_neigh_impl.h
@@ -87,6 +87,9 @@ ForceSNAP<NeighborClass>::ForceSNAP(char** args, System* system_, bool half_neig
 #elif defined(KOKKOS_ENABLE_HIP)
       std::is_same<Kokkos::DefaultExecutionSpace,Kokkos::Experimental::HIP>::value ?
           Kokkos::DefaultExecutionSpace::concurrency()/vector_length :
+#elif defined(KOKKOS_ENABLE_SYCL)
+      std::is_same<Kokkos::DefaultExecutionSpace,Kokkos::Experimental::SYCL>::value ?
+          Kokkos::DefaultExecutionSpace::concurrency()/vector_length :
 #else
           Kokkos::DefaultExecutionSpace::concurrency();
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -179,7 +179,7 @@ t_scalar3<Scalar> operator *
   return t_scalar3<Scalar>(a.x*b,a.y*b,a.z*b);
 }
 
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL)
 #define EMD_ENABLE_GPU
 #endif
 


### PR DESCRIPTION
Nothing too surprising here but we also need to use an execution space instance to call `print_configuration`.